### PR TITLE
NextCloudRichObject: Initialization with required props and support s…

### DIFF
--- a/nextcloud_async/api/ocs/talk/rich_objects.py
+++ b/nextcloud_async/api/ocs/talk/rich_objects.py
@@ -101,28 +101,21 @@ class File(NextCloudTalkRichObject):
 
     object_type = 'file'
     path = ''
-    link = ''
 
-    def __init__(self, name: str, path: str, link: str):
+    def __init__(self, name: str, path: str, **kwargs):
         """Set file object metadata."""
-        data = {
+        init = {
             'id': name,
             'name': name,
             'path': path,
-            'link': link,
         }
+        data = { **init, **kwargs }
         super().__init__(**data)
 
     @property
     def metadata(self):
         """Return object metadata."""
-        return {
-            'id': self.id,
-            'name': self.name,
-            'path': self.path,
-            'link': self.link,
-        }
-
+        return self.__dict__
 
 class Form(NextCloudTalkRichObject):
     """Form."""

--- a/nextcloud_async/api/ocs/talk/rich_objects.py
+++ b/nextcloud_async/api/ocs/talk/rich_objects.py
@@ -102,8 +102,14 @@ class File(NextCloudTalkRichObject):
     object_type = 'file'
     path = ''
 
+    allowed_props = ['size', 'link', 'mimetype', 'preview-available', 'mtime']
+
     def __init__(self, name: str, path: str, **kwargs):
         """Set file object metadata."""
+
+        if not all(key in self.allowed_props for key in kwargs):
+            raise ValueError(f'Supported properties {self.allowed_props}')
+
         init = {
             'id': name,
             'name': name,


### PR DESCRIPTION
Based on [RichObject Doc](https://github.com/nextcloud/server/blob/master/lib/public/RichObjectStrings/Definitions.php#L316) I have refactored File class:
- Remove link prop because it is not required ([id, name and path are required]
- Can initialize with  other properties
- Check for props if are on the list of allowed props 
- Avoid repeat metadata (already in __dict__)