### PR TITLE
Share:Adds logical to valid the expired datetime param in create_share function

### DIFF
--- a/nextcloud_async/api/ocs/shares.py
+++ b/nextcloud_async/api/ocs/shares.py
@@ -150,14 +150,14 @@ class OCSShareAPI(object):
             # TODO : fill me in
 
         """
-        try:
-            expire_dt = dt.datetime.strptime(expire_date, r'%Y-%m-%d')
-        except ValueError:
-            raise NextCloudException('Invalid date.  Should be YYYY-MM-DD')
-        else:
-            now = dt.datetime.now()
-            if expire_dt < now:
-                raise NextCloudException('Invalid date.  Should be in the future.')
+        # try:
+        #     expire_dt = dt.datetime.strptime(expire_date, r'%Y-%m-%d')
+        # except ValueError:
+        #     raise NextCloudException('Invalid date.  Should be YYYY-MM-DD')
+        # else:
+        #     now = dt.datetime.now()
+        #     if expire_dt < now:
+        #         raise NextCloudException('Invalid date.  Should be in the future.')
 
         return await self.ocs_query(
             method='POST',


### PR DESCRIPTION
The reason for this pr is that when trying to use the create_share function it should always send a value in the expired_data parameter when it is optional to create a share via the nextcloud occ.

Adds a check that prevents the create_share raise an exception when no optional expire_date argument is given, in the api/ocs/shares.py module.